### PR TITLE
change template ci from poetry-lock to poetry-check; update default contact details

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -23,4 +23,4 @@ repos:
   - repo: https://github.com/python-poetry/poetry
     rev: '1.7.0'
     hooks:
-    - id: poetry-lock
+    - id: poetry-check

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -2,10 +2,10 @@
 name = "{{cookiecutter.repo_name}}"
 version = "0.1.0"
 description = ""
-authors = ["CPR-tech-team <tech@climatepolicyradar.org>"]
+authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "~3.10"
 uvicorn = {extras = ["standard"], version = "^0.20.0"}
 fastapi = "^0.92.0"
 

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 
 [tool.poetry.dependencies]
-python = "~3.10"
+python = "^3.9"
 uvicorn = {extras = ["standard"], version = "^0.20.0"}
 fastapi = "^0.92.0"
 


### PR DESCRIPTION
as done in https://github.com/climatepolicyradar/metrics/pull/33. This checks consistency, rather than rerunning lock.

Also, `poetry lock` is replaced with `poetry check --lock` in new versions of poetry.